### PR TITLE
Clearfix on blockquote

### DIFF
--- a/sass/partials/_typography.scss
+++ b/sass/partials/_typography.scss
@@ -96,6 +96,7 @@ blockquote  {
 	margin: 1.5em;
 	color: #666;
 	font-style: italic;
+	overflow: hidden;
 }
 
 .quote-left {


### PR DESCRIPTION
![screen shot 2014-09-17 at 14 41 05](https://cloud.githubusercontent.com/assets/2742949/4304402/6920f4ce-3e70-11e4-9238-cb945f8a2dcb.png)
The pullquote contains a floated ‘cite’ element. This isn’t being
cleared at the moment - if the following paragraph starts with 1 or 2
characters, they’re floated next to this.
