### PR TITLE
Change banner link references

### DIFF
--- a/template.html
+++ b/template.html
@@ -93,13 +93,13 @@
 				
 				<nav class="masthead__nav m-clear">
                     <ul class="masthead__list">
-                        <li class="masthead__item"><a href="index.php" class="masthead__link">UCL Home</a>
+                        <li class="masthead__item"><a href="/" class="masthead__link">UCL Home</a>
                         </li>
-                        <li class="masthead__item"><a href="prospective-students.php" class="masthead__link">Prospective students</a>
+                        <li class="masthead__item"><a href="/prospective-students" class="masthead__link">Prospective students</a>
                         </li>
-                        <li class="masthead__item"><a href="current-students.php" class="masthead__link">Current students</a>
+                        <li class="masthead__item"><a href="/students" class="masthead__link">Current students</a>
                         </li>
-                        <li class="masthead__item"><a href="staff.php" class="masthead__link">Staff</a>
+                        <li class="masthead__item"><a href="/staff" class="masthead__link">Staff</a>
                         </li>
                     </ul>
                 </nav>


### PR DESCRIPTION
Current banner link references are relative to the url path, not
to domain root (so e.g. on the Maps site, the Home link would go to
/maps/index.php rather than /). Sorry if there’s a good reason for this
though!