### PR TITLE
removed semi-colon so we can debug non-minified all-site js

### DIFF
--- a/js/src/all-site/lazyload.js
+++ b/js/src/all-site/lazyload.js
@@ -77,4 +77,4 @@
 		processScroll();
 		addEventListener('scroll',processScroll);
 
-}(this);​
+}(this)


### PR DESCRIPTION
The final line in lazyload.js had a semi colon which caused a js error when the all-site.js file was created, so we couldn't work with the non-minified all-site.js in development (unless there's a way I haven't seen?)

Minification puts a comma in anyway, so suggest we remove the semi colon as it's not needed.