### PR TITLE
sass lint only log errors

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -81,6 +81,7 @@ module.exports = function(grunt) {
 		    ,reporterOutput: 'scss-lint-report.xml'
 		    ,colorizeOutput: true
 		    ,maxBuffer: '<%= pkg.lintBuffer %>'
+        ,force: true
 		  }
 		}
 });


### PR DESCRIPTION
- without this flag grunt task fails if there are errors. lets just log them not fail for now